### PR TITLE
Update instructions to match repo name

### DIFF
--- a/INSTALL.Debian
+++ b/INSTALL.Debian
@@ -6,11 +6,11 @@ Debian Squeeze.
 If you haven't yet downlaoded the git repo which holds the
 necessary software, you can do that this way;
 
-$ git clone git://github.com/RobertCNelson/netinstall-omap.git
+$ git clone git://github.com/RobertCNelson/netinstall.git
 
 Then change to the directory you have just cloned;
 
-$ cd netinstall-omap
+$ cd netinstall
 
 The following command is an example of what you have to do to
 install the correct distro onto the SD card;

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-git clone git://github.com/RobertCNelson/netinstall-omap.git
-cd netinstall-omap
+git clone git://github.com/RobertCNelson/netinstall.git
+cd netinstall
 sudo ./mk_mmc.sh --mmc /dev/sdX --uboot <dev board> --distro <distro> --firmware
 
 Bugs email: "bugs at rcn-ee.com"


### PR DESCRIPTION
Was "netinstall-omap" but now "netinstall".

Signed-off-by: Andrew Bradford andrew@bradfordembedded.com
