### PR TITLE
image download +b1 has been changed to +b2 for wheezy-armhf

### DIFF
--- a/lib/distro.conf
+++ b/lib/distro.conf
@@ -61,9 +61,9 @@ wheezy-armel-netboot)
 	NETINSTALL="initrd.gz"
 	;;
 wheezy-armhf-netboot)
-	#10-Oct-2013
+	#08-Feb-2014
 	#http://ftp.us.debian.org/debian/dists/wheezy/main/installer-armhf/
-	NETIMAGE="20130613+deb7u1+b1"
+	NETIMAGE="20130613+deb7u1+b2"
 	TEST_MD5SUM="6a0197b064a9cdd23b25e93bc69e9221"
 	HTTP_IMAGE="http://ftp.debian.org/debian/dists"
 	BASE_IMAGE="mx5/netboot/efikamx"


### PR DESCRIPTION
When running the mk_mmc.sh script for Debian wheezy-armhf the
following error results.

jeri@hudson:~/beagleboard/netinstall$ sudo ./mk_mmc.sh --mmc /dev/sdb --dtb am335x-boneblack --distro wheezy-armhf

...
## Downloading NetInstall Image

--2014-02-08 10:09:24--  http://ftp.debian.org/debian/dists/wheezy/main/installer-armhf/20130613+deb7u1+b1/images/mx5/netboot/efikamx/uInitrd
Resolving ftp.debian.org (ftp.debian.org)... 130.89.148.12, 2001:610:1908:b000::148:12
Connecting to ftp.debian.org (ftp.debian.org)|130.89.148.12|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2014-02-08 10:09:24 ERROR 404: Not Found.

jeri@hudson:~/beagleboard/netinstall$

It appears that the url has changed from +b1 to +b2

old url, broken (+b1)
http://ftp.debian.org/debian/dists/wheezy/main/installer-armhf/20130613+deb7u1+b1/images/mx5/netboot/efikamx/uInitrd

new url, OK (+b2)
http://ftp.debian.org/debian/dists/wheezy/main/installer-armhf/20130613+deb7u1+b2/images/mx5/netboot/efikamx/
