### PR TITLE
Fixed error when FDISK in check_mmc() returns multiple matches.

### DIFF
--- a/mk_mmc.sh
+++ b/mk_mmc.sh
@@ -1268,7 +1268,7 @@ populate_boot () {
 }
 
 check_mmc () {
-	FDISK=$(LC_ALL=C fdisk -l 2>/dev/null | grep "Disk ${media}" | awk '{print $2}')
+	FDISK=$(LC_ALL=C fdisk -l 2>/dev/null | grep "Disk ${media}[^(a-z,A-Z,0-9)]" | awk '{print $2}')
 
 	if [ "x${FDISK}" = "x${media}:" ] ; then
 		echo ""


### PR DESCRIPTION
When calling mk_mmc.sh with a --device flag where the device name matches the beginning of several devices, the variable FDISK will be assigned several rows of matches:

Ex.
Calling mk_mmc.sh with --device /dev/mmcblk0 on a system where the device tree looks like this:

```
/dev/mmcblk0
/dev/mmcblk0boot1
/dev/mmcblk0boot2
```

will assign FDISK with all those matches. Hence the comparison on line 1273 will fail
even though the device exist.

Example output from the program:

```
./mk_mmc.sh --mmc /dev/mmcblk0 --dtb am335x-boneblack --distro wheezy-armhf --firmware

Are you sure? I Don't see [/dev/mmcblk0], here is what I do see...

fdisk -l:
Disk /dev/mmcblk0: 1920 MB, 1920991232 bytes, 3751936 sectors
Disk /dev/mmcblk0boot1: 1 MB, 1048576 bytes, 2048 sectors
Disk /dev/mmcblk0boot0: 1 MB, 1048576 bytes, 2048 sectors
```

My solution is simple but will clearly fail if the other matches contains anything else than a-z,A-Z,0-9 after the similar characters in their names. Maybe a better regexp would be appropriate.
