### PR TITLE
updated doc references of --uboot to --dtb

### DIFF
--- a/INSTALL.Debian
+++ b/INSTALL.Debian
@@ -15,7 +15,7 @@ $ cd netinstall
 The following command is an example of what you have to do to
 install the correct distro onto the SD card;
 
-./mk_mmc.sh --mmc /dev/sdX --uboot <dev board> --distro <distro> --firmware
+./mk_mmc.sh --mmc /dev/sdX --dtb <dev board> --distro <distro> --firmware
 
 You'll need to customize this of course based on your particular needs. 
 For example, your SD card might be on a different partition, you can use
@@ -32,7 +32,7 @@ for the --mmc flag, like this;
 
 $ sudo ./mk_mmc.sh --mmc /dev/sdb/
 
-You'll need to also provide the correct argument to the --uboot and the 
+You'll need to also provide the correct argument to the --dtb and the 
 --distro arguments. In my case, I did this;
 
 $ sudo ./mk_mmc.sh --mmc /dev/sdb/ --dtb omap3-beagle-xm --distro wheezy-armhf

--- a/mk_mmc.sh
+++ b/mk_mmc.sh
@@ -1539,7 +1539,7 @@ check_distro () {
 }
 
 usage () {
-	echo "usage: sudo $(basename $0) --mmc /dev/sdX --uboot <dev board>"
+	echo "usage: sudo $(basename $0) --mmc /dev/sdX --dtb <dev board>"
 	#tabed to match 
 		cat <<-__EOF__
 			Script Version git: ${GIT_VERSION}


### PR DESCRIPTION
The --uboot option has been replaced by the --dtb
option (See mk_mmc.sh line 1348 for more info).
All documentation related references to --uboot have
been replaced with --dtb.

The code for generating an error if --uboot is
used in mk_mmc.sh has been left in place.
