### PR TITLE
updated to latest Debian-installer network boot image

### DIFF
--- a/lib/distro.conf
+++ b/lib/distro.conf
@@ -23,10 +23,10 @@ utopic-armhf-netboot)
 	NETINSTALL="initrd.gz"
 	;;
 wheezy-armhf-netboot)
-	#24-Apr-2014
+	#13-Oct-2014
 	#http://ftp.us.debian.org/debian/dists/wheezy/main/installer-armhf/
-	NETIMAGE="20130613+deb7u2+b1"
-	TEST_MD5SUM="6a3a44be3a9b7cdf50a1cf94c1b5f176"
+	NETIMAGE="20130613+deb7u2+b3"
+	TEST_MD5SUM="7a1062c8a62f9f77af408324dd9aa263"
 	HTTP_IMAGE="http://ftp.debian.org/debian/dists"
 	BASE_IMAGE="mx5/netboot/efikamx"
 	UBOOTWRAPPER=1


### PR DESCRIPTION
Attempted to use this today and was getting some 404 errors, updated to what is currently there.
